### PR TITLE
Align site imagery with legacy design

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,15 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="dark scroll-smooth">
-      <body className="min-h-screen flex flex-col bg-gray-900 text-gray-100">
+      <body
+        className="min-h-screen flex flex-col bg-gray-900 text-gray-100"
+        style={{
+          backgroundImage: "url('/assets/image8.png')",
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+        }}
+      >
         <Header />
         <main className="flex-1 px-4 sm:px-6 md:px-8 max-w-7xl mx-auto w-full">
           {children}

--- a/app/mining/page.tsx
+++ b/app/mining/page.tsx
@@ -20,68 +20,78 @@ export default function MiningPage() {
     { block: 20_000, reward: 0.0000 },
   ];
   return (
-    <div className="space-y-12 py-10">
-      <h1 className="text-3xl sm:text-4xl font-bold text-center">Mining & Emission</h1>
-      <p className="max-w-4xl mx-auto text-center text-gray-600 dark:text-gray-300">
-        AlynCoin uses a hybrid proof‑of‑work consensus combining <strong>BLAKE3</strong> and
-        <strong>Keccak</strong> hashing. This approach blends energy‑efficient hashing with
-        robust security. Difficulty adjusts dynamically via a linearly weighted moving
-        average (LWMA) algorithm, maintaining consistent block times even as network hash
-        power fluctuates.
-      </p>
+    <section
+      className="relative py-10"
+      style={{
+        backgroundImage: "url('/assets/image9.png')",
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
+    >
+      <div className="absolute inset-0 bg-black/60" />
+      <div className="relative z-10 space-y-12">
+        <h1 className="text-3xl sm:text-4xl font-bold text-center">Mining & Emission</h1>
+        <p className="max-w-4xl mx-auto text-center text-gray-200">
+          AlynCoin uses a hybrid proof‑of‑work consensus combining <strong>BLAKE3</strong> and
+          <strong>Keccak</strong> hashing. This approach blends energy‑efficient hashing with
+          robust security. Difficulty adjusts dynamically via a linearly weighted moving
+          average (LWMA) algorithm, maintaining consistent block times even as network hash
+          power fluctuates.
+        </p>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 max-w-5xl mx-auto">
-        <MiningCard
-          icon={<Cpu className="h-8 w-8 text-primary" />}
-          title="Hybrid PoW"
-          description="Combines BLAKE3 and Keccak hashing for both efficiency and resilience."
-        />
-        <MiningCard
-          icon={<GaugeCircle className="h-8 w-8 text-primary" />}
-          title="Dynamic Difficulty"
-          description="Linearly weighted moving average algorithm keeps block times stable and fair."
-        />
-        <MiningCard
-          icon={<Flame className="h-8 w-8 text-primary" />}
-          title="Emission Schedule"
-          description="Rewards start at 25 ALYN and decay ~0.09% per block with a 0.25 ALYN tail emission."
-        />
-        <MiningCard
-          icon={<DollarSign className="h-8 w-8 text-primary" />}
-          title="Burn & Developer Fund"
-          description="Transaction fees are partially burned and partially allocated to the DAO treasury."
-        />
-      </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 max-w-5xl mx-auto">
+          <MiningCard
+            icon={<Cpu className="h-8 w-8 text-primary" />}
+            title="Hybrid PoW"
+            description="Combines BLAKE3 and Keccak hashing for both efficiency and resilience."
+          />
+          <MiningCard
+            icon={<GaugeCircle className="h-8 w-8 text-primary" />}
+            title="Dynamic Difficulty"
+            description="Linearly weighted moving average algorithm keeps block times stable and fair."
+          />
+          <MiningCard
+            icon={<Flame className="h-8 w-8 text-primary" />}
+            title="Emission Schedule"
+            description="Rewards start at 25 ALYN and decay ~0.09% per block with a 0.25 ALYN tail emission."
+          />
+          <MiningCard
+            icon={<DollarSign className="h-8 w-8 text-primary" />}
+            title="Burn & Developer Fund"
+            description="Transaction fees are partially burned and partially allocated to the DAO treasury."
+          />
+        </div>
 
-      {/* Chart Section */}
-      <div className="max-w-4xl mx-auto">
-        <h2 className="text-2xl font-semibold text-center mb-4">Block Reward Decay</h2>
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={emissionData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
-              <XAxis dataKey="block" tickFormatter={(v) => v.toLocaleString()} />
-              <YAxis label={{ value: 'Reward (ALYN)', angle: -90, position: 'insideLeft' }} />
-              <Tooltip
-                contentStyle={{ backgroundColor: '#fff', color: '#000', borderRadius: '0.375rem', padding: '0.5rem' }}
-                formatter={(value: number) => `${value.toFixed(4)} ALYN`}
-              />
-              <Line type="monotone" dataKey="reward" stroke="#008080" strokeWidth={2} dot={{ r: 1 }} />
-            </LineChart>
-          </ResponsiveContainer>
+        {/* Chart Section */}
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-2xl font-semibold text-center mb-4">Block Reward Decay</h2>
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={emissionData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-gray-400" />
+                <XAxis dataKey="block" tickFormatter={(v) => v.toLocaleString()} />
+                <YAxis label={{ value: 'Reward (ALYN)', angle: -90, position: 'insideLeft' }} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: '#fff', color: '#000', borderRadius: '0.375rem', padding: '0.5rem' }}
+                  formatter={(value: number) => `${value.toFixed(4)} ALYN`}
+                />
+                <Line type="monotone" dataKey="reward" stroke="#008080" strokeWidth={2} dot={{ r: 1 }} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+
+        <div className="max-w-4xl mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Why Hybrid PoW?</h2>
+          <p className="text-gray-200">
+            Combining two cryptographic hashes mitigates the risk of single‑algorithm breakthroughs and
+            distributes mining hardware diversity. BLAKE3 provides a fast, energy‑efficient baseline,
+            while Keccak offers proven resistance against a range of cryptanalytic attacks. Together
+            they deliver a more balanced mining landscape than typical single‑hash networks.
+          </p>
         </div>
       </div>
-
-      <div className="max-w-4xl mx-auto space-y-4">
-        <h2 className="text-2xl font-semibold">Why Hybrid PoW?</h2>
-        <p className="text-gray-600 dark:text-gray-300">
-          Combining two cryptographic hashes mitigates the risk of single‑algorithm breakthroughs and
-          distributes mining hardware diversity. BLAKE3 provides a fast, energy‑efficient baseline,
-          while Keccak offers proven resistance against a range of cryptanalytic attacks. Together
-          they deliver a more balanced mining landscape than typical single‑hash networks.
-        </p>
-      </div>
-    </div>
+    </section>
   );
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function HomePage() {
       <section
         className="relative flex flex-col items-center text-center pt-16 sm:pt-24 pb-20"
         style={{
-          backgroundImage: "url('/assets/image1.png')",
+          backgroundImage: "url('/assets/image3.png')",
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}
@@ -48,14 +48,6 @@ export default function HomePage() {
               rel="noopener noreferrer"
             >
               Read Whitepaper
-            </a>
-            <a
-              href="/downloads/pitch_deck.pdf"
-              className="inline-flex items-center justify-center rounded-md border border-primary px-6 py-3 text-primary font-medium shadow hover:bg-primary/10 dark:hover:bg-primary/20 transition-colors"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View Pitch Deck
             </a>
             <a
               href="/downloads/AlyncoinGPTresearch.pdf"
@@ -96,7 +88,7 @@ export default function HomePage() {
         id="features"
         className="relative py-24"
         style={{
-          backgroundImage: "url('/assets/image3.png')",
+          backgroundImage: "url('/assets/image4.png')",
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}
@@ -144,7 +136,7 @@ export default function HomePage() {
         id="progress"
         className="relative py-24"
         style={{
-          backgroundImage: "url('/assets/image4.png')",
+          backgroundImage: "url('/assets/image5.png')",
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -42,26 +42,36 @@ export default function ProgressPage() {
     },
   ];
   return (
-    <div className="space-y-12 py-10">
-      <h1 className="text-3xl sm:text-4xl font-bold text-center">Project Progress</h1>
-      <p className="max-w-4xl mx-auto text-center text-gray-600 dark:text-gray-300">
-        Since inception, AlynCoin has achieved significant technical milestones. Below is a
-        snapshot of what’s done, what’s underway and what’s next on the roadmap.
-      </p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-5xl mx-auto">
-        {milestones.map(({ title, status, description }) => (
-          <div
-            key={title}
-            className="p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm space-y-2"
-          >
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold">{title}</h3>
-              <span className="text-sm font-medium text-primary">{status}</span>
+    <section
+      className="relative py-10"
+      style={{
+        backgroundImage: "url('/assets/image5.png')",
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
+    >
+      <div className="absolute inset-0 bg-black/60" />
+      <div className="relative z-10 space-y-12">
+        <h1 className="text-3xl sm:text-4xl font-bold text-center text-white">Project Progress</h1>
+        <p className="max-w-4xl mx-auto text-center text-gray-200">
+          Since inception, AlynCoin has achieved significant technical milestones. Below is a
+          snapshot of what’s done, what’s underway and what’s next on the roadmap.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-5xl mx-auto">
+          {milestones.map(({ title, status, description }) => (
+            <div
+              key={title}
+              className="p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white/90 dark:bg-gray-800/90 shadow-sm space-y-2"
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold">{title}</h3>
+                <span className="text-sm font-medium text-primary">{status}</span>
+              </div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
             </div>
-            <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -15,6 +15,7 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const navItems = [
     { label: 'Home', href: '/' },
+    { label: 'About', href: '/about' },
     { label: 'Tokenomics', href: '/tokenomics' },
     { label: 'Governance', href: '/governance' },
     { label: 'Mining', href: '/mining' },
@@ -22,19 +23,19 @@ export default function Header() {
     { label: 'Downloads', href: '/downloads' },
   ];
   return (
-    <header className="sticky top-0 z-50 backdrop-blur bg-white/80 dark:bg-gray-900/80 border-b border-gray-200 dark:border-gray-700">
+    <header className="sticky top-0 z-50 backdrop-blur bg-black/80 text-white border-b border-gray-800">
       <div className="mx-auto max-w-7xl flex items-center justify-between px-4 py-4">
-        <Link href="/" className="flex items-center space-x-2 hover:text-primary dark:hover:text-primary">
-          <Image src="/assets/logo.png" alt="AlynCoin logo" width={32} height={32} />
+        <Link href="/" className="flex items-center space-x-2 text-white hover:text-primary">
+          <Image src="/assets/logo.png" alt="AlynCoin logo" width={40} height={40} />
           <span className="text-2xl font-semibold tracking-tight">AlynCoin</span>
         </Link>
         {/* Desktop navigation */}
-        <nav className="hidden md:flex space-x-6 text-sm font-medium">
+        <nav className="hidden md:flex space-x-6 text-sm font-medium text-white">
           {navItems.map((item) => (
             <Link
               key={item.href}
               href={item.href}
-              className="hover:text-primary dark:hover:text-primary transition-colors"
+              className="hover:text-primary transition-colors"
             >
               {item.label}
             </Link>
@@ -43,7 +44,7 @@ export default function Header() {
         {/* Mobile hamburger toggle */}
         <button
           type="button"
-          className="md:hidden inline-flex items-center justify-center rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-primary"
+          className="md:hidden inline-flex items-center justify-center rounded-md p-2 text-white focus:outline-none focus:ring-2 focus:ring-primary"
           aria-label="Toggle navigation menu"
           onClick={() => setOpen(!open)}
         >
@@ -52,13 +53,13 @@ export default function Header() {
       </div>
       {/* Mobile menu */}
       {open && (
-        <div className="md:hidden border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+        <div className="md:hidden border-t border-gray-800 bg-black">
           <nav className="px-4 py-2 space-y-1">
             {navItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
-                className="block px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="block px-3 py-2 rounded-md text-sm font-medium text-white hover:bg-gray-800"
                 onClick={() => setOpen(false)}
               >
                 {item.label}


### PR DESCRIPTION
## Summary
- Darken header, enlarge logo and add About link for clearer navigation
- Restore legacy image mapping: new global background, updated hero, features, progress and mining visuals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68972eb170d0832f9e3da9d42f5584c7